### PR TITLE
Use deep copy for self.keys

### DIFF
--- a/examples/async/keyboard_example.py
+++ b/examples/async/keyboard_example.py
@@ -71,7 +71,7 @@ class Device:
     # Input loop
     async def gather_input(self):
         while self.active:
-            prevkeys = self.keys
+            prevkeys = list(self.keys)
             self.keys.clear()
 
             # Read pin values and update variables


### PR DESCRIPTION
This ensures that `prevkeys` isn't just a pointer to `self.keys`. By copying we ensure that updating values in `self.keys` does not modify the original values (`prevkeys`) so that we can detect changes.